### PR TITLE
Prepend `/bin/bash` in system service

### DIFF
--- a/ssh_public_key/etc/systemd/system/ssh-permission-monitor.service
+++ b/ssh_public_key/etc/systemd/system/ssh-permission-monitor.service
@@ -3,7 +3,7 @@ Description=Monitor and enforce permissions for home directory and .ssh
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/check_and_fix_ssh_permissions.sh
+ExecStart=/bin/bash /usr/local/bin/check_and_fix_ssh_permissions.sh
 Restart=always
 User=root
 ExecStartPre=/bin/bash -c 'while ! systemctl is-active ssh || ! [ -d /home/<USER NAME> ]; do echo "Waiting for ssh and /home/<USER NAME>..."; sleep 5; done'


### PR DESCRIPTION
Prepend `/bin/bash` in system service. Without  `/bin/bash` systemd may throw error 203 when executing the script.